### PR TITLE
Add channel.enable_output(is_enabled) method

### DIFF
--- a/feeltech/__init__.py
+++ b/feeltech/__init__.py
@@ -87,6 +87,10 @@ class Channel:
     def offset(self, o = None):
         self._ft.send(self._prefix + "o%2.2f" % o)
 
+    @getset
+    def enable_output(self, enabled = None):
+        self._ft.send(self._prefix + "g%d" % (1 if enabled else 0))
+
     def start_sweep(self, freq_start, freq_end, time = 10, type = LINEAR):
         if self._i != 1:
             raise NotImplementedError("Sweep supported only on channel 1")


### PR DESCRIPTION
Hello,

I was using your library to write a fy3200s driver for https://github.com/4x1md/sds1004x_bode

Discovered this through trial and error. Works for both channels:

    bg0 - turn channel 1 output off
    bg1 - turn channel 1 output on
    dg0 - turn channel 2 output off
    dg1 - turn channel 2 output on

Thanks for your library. Works great.
